### PR TITLE
Update configure.rst

### DIFF
--- a/technical/customise/app/configure.rst
+++ b/technical/customise/app/configure.rst
@@ -46,8 +46,8 @@ The core OppiaMobile android app is configured to point to our demonstration ser
 have your version of the app automatically point to your server, you need to update the ``OPPIA_SERVER_DEFAULT`` value in
 the settings file (see  :doc:`./settings` for more info on this topic).
 
-* Open the ``/res/values/untranslated.xml`` file
-* Change the ``prefServerDefault`` string to be the url to your server
+* Open the ``oppia-default.properties`` file
+* Change the ``OPPIA_SERVER_DEFAULT`` and ``OPPIA_SERVER_HOST`` string to be the url to your server
 
 App title and welcome message
 ------------------------------------


### PR DESCRIPTION
/res/values/untranslated.xml  does not have the said settings, This has been moved to the oppia-default.properties. 